### PR TITLE
Added brigadier's getSmartUsage & fixes

### DIFF
--- a/src/tree/RootCommandNode.ts
+++ b/src/tree/RootCommandNode.ts
@@ -10,7 +10,7 @@ import {
 export class RootCommandNode<S> extends CommandNode<S> {
 
     constructor() {
-        super(null, c => null, null, c => null, false);
+        super(null, c => true, null, c => null, false);
     }
 
     parse(reader: StringReader, contextBuilder: CommandContextBuilder<S>): void {


### PR DESCRIPTION
Fixes two issues:

- The RootCommandNode had a predicate requirement of null, so you could never "use" the root node, which doesn't make sense.
- The display text for redirection did not include a space after the arrow, which was hard to read.

Adds brigadier's smart usage, which gives a Map<CommandNode<T>, string> of usage strings which give more compressed information than the getAllUsage function.