### PR TITLE
Add type parameters to argument builder factories

### DIFF
--- a/src/builder/LiteralArgumentBuilder.ts
+++ b/src/builder/LiteralArgumentBuilder.ts
@@ -25,6 +25,6 @@ export class LiteralArgumentBuilder<S> extends ArgumentBuilder<S, LiteralArgumen
     }
 }
 
-export function literal(name: string): LiteralArgumentBuilder<any> {
-    return new LiteralArgumentBuilder<any>(name);
+export function literal<S = any>(name: string): LiteralArgumentBuilder<S> {
+    return new LiteralArgumentBuilder(name);
 }

--- a/src/builder/RequiredArgumentBuilder.ts
+++ b/src/builder/RequiredArgumentBuilder.ts
@@ -35,6 +35,6 @@ export class RequiredArgumentBuilder<S, T> extends ArgumentBuilder<S, RequiredAr
     }
 }
 
-export function argument(name: string, type: ArgumentType<any>): RequiredArgumentBuilder<any, any> {
-    return new RequiredArgumentBuilder<any, any>(name, type);
+export function argument<S = any, T = any>(name: string, type: ArgumentType<T>): RequiredArgumentBuilder<S, T> {
+    return new RequiredArgumentBuilder(name, type);
 }


### PR DESCRIPTION
This pull request adds type parameters to the `literal` and `argument` factories for argument builders. This change allows users to specify a command source before chaining builder methods. All added type parameters have a default of `any` for backwards compatibility.

Fixes #16